### PR TITLE
pendo fix

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -1143,7 +1143,7 @@ extension DropDown {
 	public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
 		let view = super.hitTest(point, with: event)
 
-		if dismissMode == .automatic && view === dismissableView {
+        if dismissMode == .automatic && view === dismissableView && event != nil {
 			cancel()
 			return nil
 		} else {


### PR DESCRIPTION
This adds an event nil check to hitTest to stop pendo from auto closing dropdowns.